### PR TITLE
Update trivy-scan.yml

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -52,7 +52,7 @@ jobs:
           brew install aquasecurity/trivy/trivy
 
           # Create trivy binary file
-          git clone --depth 1 https://github.com/aquasecurity/trivy
+          git clone --depth 1 -b "v0.22.0" https://github.com/aquasecurity/trivy
 
       - name: Run trivy to generate reports
         run: |


### PR DESCRIPTION
Pins trivy cloning to currently released trivy version.

The `develop` branch of trivy has removed the `serif` template and codified it in this commit: https://github.com/aquasecurity/trivy/commit/8da20c8c926430dbdd0477fbda999141bf948f38

Once they release a new trivy version, we can remove the `git clone` section and update scans to use `--template serif` 