### PR TITLE
Use apt-get for trivy installation

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -59,8 +59,13 @@ jobs:
       - name: Install trivy
         run: |
           set -o pipefail
-          # Download trivy binary.
-          brew install aquasecurity/trivy/trivy
+          
+          # https://aquasecurity.github.io/trivy/v0.18.3/installation/
+          sudo apt-get install wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install trivy
 
       - name: Read dismissed CVEs from Github
         run: |


### PR DESCRIPTION
Linuxbrew is no longer in the $PATH by default, swapping it out as we only install trivy via linuxbrew right now.